### PR TITLE
Remove outdated comments and revert changes made during RST.

### DIFF
--- a/neural-networks-201/Neural Networks - Part 2.ipynb
+++ b/neural-networks-201/Neural Networks - Part 2.ipynb
@@ -873,7 +873,7 @@
     "\n",
     "model = Sequential([\n",
     "            # use a single hidden layer, also with 13 nodes\n",
-    "            Dense(40, input_dim=13, activation='sigmoid'),\n",
+    "            Dense(13, input_dim=13, activation='relu'),\n",
     "            Dense(1)\n",
     "        ])"
    ]


### PR DESCRIPTION
Before adding the "Foreword" on the Python RNG, there were some comments about inconsistencies in result data. These are removed in this commit. 
